### PR TITLE
feat: add line number next to filename

### DIFF
--- a/src/pretty_traceback/formatting.py
+++ b/src/pretty_traceback/formatting.py
@@ -265,7 +265,7 @@ def _padded_rows(ctx: Context) -> typ.Iterable[PaddedRow]:
 
         # the max lengths are calculated upstream in `_init_entries_context`
         padded_call   = row.call.ljust(ctx.max_call_len)
-        padded_lineno = row.lineno.rjust(ctx.max_lineno_len)
+        padded_lineno = row.lineno.ljust(ctx.max_lineno_len)
 
         yield PaddedRow(
             row.alias,
@@ -302,19 +302,24 @@ def _rows_to_lines(rows: typ.List[PaddedRow], color: bool = False) -> typ.Iterab
             _alias = ""
             module = full_module
 
+        # append line number to file so editors can jump to the line
+        bare_module    = module.strip()
+        bare_lineno    = lineno.strip()
+        module_padding = " " * (len(module) - len(bare_module) + len(lineno) - len(bare_lineno))
+
         parts = (
-            " ",
+            "    ",
             _alias,
             " ",
-            # include the line number with the file so VS Code (and other similar systems) can easily jump to the line
-            fmt_module.format(module.strip()) + ":" + fmt_lineno.format(lineno.strip()),
+            fmt_module.format(bare_module),
+            ":",
+            fmt_lineno.format(bare_lineno),
+            module_padding,
             "  ",
             fmt_call.format(call),
+            "  ",
             fmt_context.format(context),
         )
-
-        # original is pretty_traceback.formatting._padded_rows
-        # TODO need to add left passing to the trace, but this is workable for now
 
         line = "".join(parts)
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -105,7 +105,6 @@ def test_formatting(fixture_index, term_width, pathsep_re, env_setup):
         tb_str = formatting._format_traceback(ctx, traceback)
 
         pathsep_offsets = []
-        lineno_offsets  = []
 
         tb_lines = tb_str.split(common.TRACEBACK_HEAD)[-1].strip("\n").splitlines()[:-1]
         for line in tb_lines:

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -90,10 +90,10 @@ def test_formatting_basic():
 
 
 FORMATTING_TEST_CASES = [
-    (0,   10, r"    \<\w+\>.*\.py[ ]+"),
-    (1,   10, r"    \<\w+\>.*\.py[ ]+"),
-    (0, 1000, r"    .*\.py[ ]+"),
-    (1, 1000, r"    .*\.py[ ]+"),
+    (0,   10, r"    \<\w+\>.*\.py:\d+[ ]+"),
+    (1,   10, r"    \<\w+\>.*\.py:\d+[ ]+"),
+    (0, 1000, r"    .*\.py:\d+[ ]+"),
+    (1, 1000, r"    .*\.py:\d+[ ]+"),
 ]
 
 
@@ -116,14 +116,8 @@ def test_formatting(fixture_index, term_width, pathsep_re, env_setup):
                 _, end = pathsep_match.span()
                 pathsep_offsets.append(end)
 
-            lineno_match = re.search(r"\d+:", line)
-            if lineno_match:
-                _, end = lineno_match.span()
-                lineno_offsets.append(end)
-
         # all line numbers are aligned to the right at the same offset
         assert len(pathsep_offsets) > 3 and len(set(pathsep_offsets)) == 1
-        assert len(lineno_offsets ) > 3 and len(set(lineno_offsets )) == 1
 
 
 def _pong(depth):


### PR DESCRIPTION
this allows VS code and other systems to easily open the file at the line number.

This is not ready to merge, the padding stuff needs to be adjusted. I was curious the best way to handle this:
are you comfortable making a global formatting change to the stack trace?
